### PR TITLE
Brands slider sortorder

### DIFF
--- a/src/templates/cms/home.template.html
+++ b/src/templates/cms/home.template.html
@@ -93,7 +93,7 @@ $(document).ready(function(){
 </div>
 
 
-[%thumb_list type:'content' content_type:'brand' template:'brand' limit:'12' sortby:'sortorder'%]
+[%thumb_list type:'content' content_type:'brand' template:'brand' limit:'12' sortby:'sortorder-desc'%]
     [%param *header%]
         <div class="container-fluid no-padding brands-panel-container neutral-light-background">
             <div class="container brands-panel neutral-light-background">


### PR DESCRIPTION
In the documentation, it says the highest 12 will display. Currently, it displays in ascending order.